### PR TITLE
feature: Exclude .md files from prettier linting

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -19,4 +19,4 @@ jobs:
         run: npm ci
 
       - name: Check formatting
-        run: npx prettier --check .
+        run: npx prettier . '!**/*.md' --check

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# ignoring the READEME file due to linting sometimes messing up Markdown Tables
+**/*.md


### PR DESCRIPTION
Added exclusions on prettier linting on .md files. Due to the recent hiccup with the RSS Feed Bot repo. The README contained a table, in which prettier messed up the formatting. 